### PR TITLE
feat: shared data keys implementation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
         "Millis",
         "Mosquitto",
         "mqtt",
+        "mwcmanager",
         "ZARIOT"
     ]
 }

--- a/flutter/iot_receiver/lib/forms/data_owner_form.dart
+++ b/flutter/iot_receiver/lib/forms/data_owner_form.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:form_builder_validators/form_builder_validators.dart';
+import 'package:auto_size_text/auto_size_text.dart';
+
+// Some Form templates to reuse in New and Edit for devices
+
+FormBuilderDropdown dataOwnerDeviceSelector(BuildContext context, items) {
+  return FormBuilderDropdown(
+    name: "device_selector",
+    items: items,
+    decoration: const InputDecoration(
+      // labelText: 'Select Device',
+      // labelStyle: TextStyle(fontWeight: FontWeight.bold),
+      hintText: 'Select Device',
+    ),
+  );
+}
+
+FormBuilderTextField dataOwnerAtsignForm(
+    BuildContext context, String initialValue) {
+  return FormBuilderTextField(
+      initialValue: initialValue.toString(),
+      name: '@dataOwner',
+      decoration: const InputDecoration(
+        labelText: 'Data Owner\'s atSign',
+        // fillColor: Colors.white,
+        // focusColor: Colors.lightGreenAccent,
+        labelStyle: TextStyle(fontWeight: FontWeight.bold),
+      ),
+      validator: FormBuilderValidators.required(),
+      style: const TextStyle(fontSize: 20, letterSpacing: 5));
+}
+
+class DataOwnerSubmitForm extends StatelessWidget {
+  const DataOwnerSubmitForm({
+    Key? key,
+    required GlobalKey<FormBuilderState> formKey,
+  })  : _formKey = formKey,
+        super(key: key);
+
+  final GlobalKey<FormBuilderState> _formKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: MaterialButton(
+        child: const AutoSizeText(
+          "Reset",
+          style: TextStyle(color: Colors.black),
+          maxLines: 1,
+          maxFontSize: 30,
+          minFontSize: 10,
+        ),
+        onPressed: () {
+          _formKey.currentState!.reset();
+        },
+      ),
+    );
+  }
+}

--- a/flutter/iot_receiver/lib/main.dart
+++ b/flutter/iot_receiver/lib/main.dart
@@ -1,11 +1,13 @@
 import 'dart:async';
 import 'package:at_app_flutter/at_app_flutter.dart' show AtEnv;
 import 'package:at_client_mobile/at_client_mobile.dart';
+import 'package:iot_receiver/screens/data_owners_screen.dart';
 import 'package:iot_receiver/screens/devices_screen.dart';
 import 'package:iot_receiver/screens/receivers_screen.dart';
 import 'package:at_utils/at_logger.dart' show AtSignLogger;
 import 'package:flutter/material.dart';
 import 'package:iot_receiver/models/iot_model.dart';
+import 'package:iot_receiver/widgets/new_data_owner_dialog.dart';
 import 'package:iot_receiver/widgets/new_device_dialog.dart';
 import 'package:iot_receiver/widgets/new_receiver_dialog.dart';
 import 'package:path_provider/path_provider.dart'
@@ -73,8 +75,10 @@ class _MyAppState extends State<MyApp> {
         OnboardingScreen.id: (_) => const OnboardingScreen(),
         ReceiversScreen.id: (_) => const ReceiversScreen(),
         DevicesScreen.id: (_) => const DevicesScreen(),
+        DataOwnersScreen.id: (_) => const DataOwnersScreen(),
         NewHrO2Device.id: (_) => const NewHrO2Device(),
         NewHrO2Receiver.id: (_) => const NewHrO2Receiver(),
+        NewHrO2DataOwner.id: (_) => const NewHrO2DataOwner(),
         //Next.id: (_) => const Next(),
       },
       initialRoute: OnboardingScreen.id,

--- a/flutter/iot_receiver/lib/screens/data_owners_screen.dart
+++ b/flutter/iot_receiver/lib/screens/data_owners_screen.dart
@@ -1,0 +1,163 @@
+import 'package:at_utils/at_logger.dart';
+import 'package:flutter/material.dart';
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:iot_receiver/models/hro2_data_owner.dart';
+import 'package:iot_receiver/services/hro2_data_service.dart';
+import 'package:iot_receiver/widgets/hro2_drawer_widget.dart';
+import 'package:iot_receiver/widgets/new_data_owner_dialog.dart';
+import 'package:new_gradient_app_bar/new_gradient_app_bar.dart';
+
+final AtSignLogger _logger = AtSignLogger('DataOwnersScreen');
+
+class DataOwnersScreen extends StatefulWidget {
+  const DataOwnersScreen({Key? key}) : super(key: key);
+  static const String id = '/data_owners_screen';
+  @override
+  State<DataOwnersScreen> createState() => _DataOwnersScreenState();
+}
+
+class _DataOwnersScreenState extends State<DataOwnersScreen> {
+  final Hro2DataService _hrO2DataService = Hro2DataService();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: NewGradientAppBar(
+        title: const AutoSizeText(
+          'Data Owners',
+          minFontSize: 5,
+          maxFontSize: 50,
+        ),
+        gradient: const LinearGradient(colors: [
+          Color.fromARGB(255, 173, 83, 78),
+          Color.fromARGB(255, 108, 169, 197)
+        ]),
+      ),
+      drawer: const HRo2DrawerWidget(),
+      body: Builder(
+          builder: (context) => FutureBuilder<List<HrO2DataOwner>>(
+              future: _hrO2DataService.getDataOwnerList(),
+              builder: (BuildContext context,
+                  AsyncSnapshot<List<HrO2DataOwner>> snapshot) {
+                List<Widget> children;
+                if (snapshot.hasData) {
+                  List<HrO2DataOwner>? hrO2DataOwnerList = snapshot.data;
+                  children = <Widget>[
+                    const Text(
+                      "The following dataOwners have been created.",
+                      overflow: TextOverflow.visible,
+                    ),
+                    const SizedBox(
+                      height: 20,
+                    ),
+                    ListView.builder(
+                        scrollDirection: Axis.vertical,
+                        shrinkWrap: true,
+                        // padding: const EdgeInsets.symmetric(
+                        //     vertical: 5, horizontal: 20),
+                        itemCount: hrO2DataOwnerList!.length,
+                        itemBuilder: (BuildContext context, int index) {
+                          final HrO2DataOwner dataOwner =
+                              hrO2DataOwnerList[index];
+                          const align = Align(
+                              alignment: Alignment.centerRight,
+                              child: Padding(
+                                padding: EdgeInsets.only(right: 16),
+                                child: Icon(Icons.delete),
+                              ));
+                          return Dismissible(
+                            key: Key(dataOwner.dataOwnerAtsign),
+                            background: Container(
+                              color: Colors.red,
+                              child: align,
+                            ),
+                            confirmDismiss: (direction) async {
+                              if (direction == DismissDirection.startToEnd) {
+                                return false;
+                              } else {
+                                bool delete = true;
+                                final snackbarController =
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(
+                                    content: Text(
+                                        'Delete ${dataOwner.dataOwnerAtsign} ?'),
+                                    action: SnackBarAction(
+                                        label: 'Cancel',
+                                        onPressed: () => delete = false),
+                                  ),
+                                );
+                                await snackbarController.closed;
+                                return delete;
+                              }
+                            },
+                            onDismissed: (_) async {
+                              hrO2DataOwnerList.remove(dataOwner);
+                              await _hrO2DataService
+                                  .putDataOwnerList(hrO2DataOwnerList);
+                              setState(() {});
+                            },
+                            child: ListTile(
+                              shape: RoundedRectangleBorder(
+                                  side: const BorderSide(
+                                      color: Colors.blue, width: 1),
+                                  borderRadius: BorderRadius.circular(10)),
+                              title: Text(
+                                  hrO2DataOwnerList[index].dataOwnerAtsign),
+                              subtitle: Text(
+                                  "${hrO2DataOwnerList[index].hrO2Device.deviceAtsign} ${hrO2DataOwnerList[index].hrO2Device.sensorName.isNotEmpty ? hrO2DataOwnerList[index].hrO2Device.sensorName : ""}"),
+                              // trailing: const Icon(Icons.navigate_next),
+                            ),
+                          );
+                        }),
+                  ];
+                } else if (snapshot.hasError) {
+                  _logger.severe(snapshot.error);
+                  children = <Widget>[
+                    const Icon(
+                      Icons.error_outline,
+                      color: Colors.red,
+                      size: 60,
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(top: 16),
+                      child: Text(
+                          '${snapshot.error}, please click the + button below to add a dataOwner.'),
+                    ),
+                  ];
+                } else {
+                  children = <Widget>[
+                    // DoOnboardWidget(
+                    //     // futurePreference: widget.futurePreference,
+                    //     ),
+                  ];
+                }
+                return Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: children,
+                  ),
+                );
+                // child:
+              })),
+      floatingActionButton: FloatingActionButton(
+        backgroundColor: Colors.green,
+        onPressed: () async {
+          var newDataOwner = await Navigator.push(
+            context,
+            MaterialPageRoute(builder: (context) => const NewHrO2DataOwner()),
+          );
+          if (newDataOwner == null) {
+          } else {
+            setState(() {
+              // dataOwners.add(newDataOwner);
+              // saveDataOwners(dataOwners);
+            });
+          }
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/flutter/iot_receiver/lib/services/hro2_data_service.dart
+++ b/flutter/iot_receiver/lib/services/hro2_data_service.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
-
 import 'package:at_client_mobile/at_client_mobile.dart';
 import 'package:at_utils/at_logger.dart';
+import 'package:iot_receiver/models/hro2_data_owner.dart';
 import 'package:iot_receiver/models/hro2_device.dart';
 import 'package:iot_receiver/models/hro2_receiver.dart';
 
@@ -27,7 +27,10 @@ class Hro2DataService {
     AtKey receiverAtKey = AtKey()..key = AppConstants.receiverListKey;
     var receiverKeyDeleted = await delete(receiverAtKey);
     _logger.info('deleteAllData.receiverKeyDeleted $receiverKeyDeleted');
-    return (deviceKeyDeleted && receiverKeyDeleted);
+    AtKey dataOwnerAtKey = AtKey()..key = AppConstants.dataOwnerListKey;
+    var dataOwnerKeyDeleted = await delete(dataOwnerAtKey);
+    _logger.info('deleteAllData.dataOwnerKeyDeleted $dataOwnerKeyDeleted');
+    return (deviceKeyDeleted && receiverKeyDeleted && dataOwnerKeyDeleted);
   }
 
   ///Returns `AtFollowsValue` for [atKey].
@@ -95,10 +98,76 @@ class Hro2DataService {
     receiverList.add(hrO2Receiver);
     AtKey atKey = AtKey()..key = AppConstants.receiverListKey;
     var value = jsonEncode(receiverList);
+    var receiverSuccess =
+        await AtClientManager.getInstance().atClient.put(atKey, value);
+    _logger.info('addReceiverToList success = $receiverSuccess');
+    AtKey dataOwnerKey = AtKey()
+      ..key = AppConstants.deviceReceiverKey
+      ..sharedWith = hrO2Receiver.receiverAtsign;
+    var sharedReceiverJson = jsonEncode(hrO2Receiver);
+    var sharedReceiverSuccess = await AtClientManager.getInstance()
+        .atClient
+        .put(dataOwnerKey, sharedReceiverJson);
+    _logger.info('shareDeviceSuccess success = $sharedReceiverSuccess');
+    return receiverSuccess && receiverSuccess;
+  }
+
+  Future<List<HrO2DataOwner>> getDataOwnerList() async {
+    AtKey atKey = AtKey()..key = AppConstants.dataOwnerListKey;
+    var data = await AtClientManager.getInstance().atClient.get(atKey);
+    _logger.info('getDataOwnerList got ${data.value}');
+    List<HrO2DataOwner> hrO2DataOwnerList;
+    hrO2DataOwnerList = (json.decode(data.value) as List)
+        .map((i) => HrO2DataOwner.fromJson(i))
+        .toList();
+    _logger.info('getDataOwnerList returning $hrO2DataOwnerList');
+    return hrO2DataOwnerList;
+  }
+
+  Future<List<HrO2DataOwner>> getDeviceDataOwnerList() async {
+    AtKey atKey = AtKey()
+      ..key = AppConstants.deviceDataOwnerKey
+      ..sharedBy = "@mwcmanager";
+    var data = await AtClientManager.getInstance().atClient.get(atKey);
+    _logger.info('getDeviceDataOwner got ${data.value}');
+    HrO2DataOwner hrO2DataOwner =
+        HrO2DataOwner.fromJson(json.decode(data.value));
+    List<HrO2DataOwner> hrO2DataOwnerList = [];
+    hrO2DataOwnerList.add(hrO2DataOwner);
+    _logger.info('getDeviceDataOwnerList returning $hrO2DataOwnerList');
+    return hrO2DataOwnerList;
+  }
+
+  Future<bool> putDataOwnerList(List<HrO2DataOwner> hrO2DataOwnerList) async {
+    AtKey atKey = AtKey()..key = AppConstants.dataOwnerListKey;
+    var value = jsonEncode(hrO2DataOwnerList);
     var response =
         await AtClientManager.getInstance().atClient.put(atKey, value);
-    _logger.info('addReceiverToList success = $response');
+    _logger.info('putDataOwnerList success = $response');
     return response;
+  }
+
+  Future<bool> addDataOwnerToList(HrO2DataOwner hrO2DataOwner) async {
+    List<HrO2DataOwner> dataOwnerList = [];
+    dataOwnerList = await getDataOwnerList().onError((error, stackTrace) async {
+      return dataOwnerList;
+    });
+    dataOwnerList.add(hrO2DataOwner);
+    AtKey deviceOwnerKey = AtKey()..key = AppConstants.dataOwnerListKey;
+    var dataOwnerJson = jsonEncode(dataOwnerList);
+    var deviceOwnerSuccess = await AtClientManager.getInstance()
+        .atClient
+        .put(deviceOwnerKey, dataOwnerJson);
+    _logger.info('addDataOwnerToList success = $deviceOwnerSuccess');
+    AtKey dataOwnerKey = AtKey()
+      ..key = AppConstants.deviceDataOwnerKey
+      ..sharedWith = hrO2DataOwner.dataOwnerAtsign;
+    var sharedDataOwnerJson = jsonEncode(hrO2DataOwner);
+    var sharedDataOwnerSuccess = await AtClientManager.getInstance()
+        .atClient
+        .put(dataOwnerKey, sharedDataOwnerJson);
+    _logger.info('shareDeviceSuccess success = $sharedDataOwnerSuccess');
+    return deviceOwnerSuccess && sharedDataOwnerSuccess;
   }
 }
 
@@ -106,5 +175,9 @@ class AppConstants {
   static const String libraryNamespace = 'iot_receiver';
   static const String deviceListKey = 'device_list.$libraryNamespace';
   static const String receiverListKey = 'receiver_list.$libraryNamespace';
+  static const String dataOwnerListKey = 'data_owner_list.$libraryNamespace';
+  static const String deviceDataOwnerKey =
+      'device_data_owner.$libraryNamespace';
+  static const String deviceReceiverKey = 'device_receiver.$libraryNamespace';
   static const int responseTimeLimit = 30;
 }

--- a/flutter/iot_receiver/lib/services/hro2_data_service.dart
+++ b/flutter/iot_receiver/lib/services/hro2_data_service.dart
@@ -159,15 +159,24 @@ class Hro2DataService {
         .atClient
         .put(deviceOwnerKey, dataOwnerJson);
     _logger.info('addDataOwnerToList success = $deviceOwnerSuccess');
+// share information to the data owner
+    var sharedDataOwnerJson = jsonEncode(hrO2DataOwner);
     AtKey dataOwnerKey = AtKey()
       ..key = AppConstants.deviceDataOwnerKey
       ..sharedWith = hrO2DataOwner.dataOwnerAtsign;
-    var sharedDataOwnerJson = jsonEncode(hrO2DataOwner);
     var sharedDataOwnerSuccess = await AtClientManager.getInstance()
         .atClient
         .put(dataOwnerKey, sharedDataOwnerJson);
     _logger.info('shareDeviceSuccess success = $sharedDataOwnerSuccess');
-    return deviceOwnerSuccess && sharedDataOwnerSuccess;
+    // Share the same object to the device
+    dataOwnerKey.sharedWith = hrO2DataOwner.hrO2Device.deviceAtsign;
+    var deviceDataOwnerSuccess = await AtClientManager.getInstance()
+        .atClient
+        .put(dataOwnerKey, sharedDataOwnerJson);
+    _logger.info('deviceDataOwnerSuccess success = $deviceDataOwnerSuccess');
+    return deviceOwnerSuccess &&
+        sharedDataOwnerSuccess &&
+        deviceDataOwnerSuccess;
   }
 }
 

--- a/flutter/iot_receiver/lib/widgets/hro2_drawer_widget.dart
+++ b/flutter/iot_receiver/lib/widgets/hro2_drawer_widget.dart
@@ -1,5 +1,9 @@
+import 'package:at_client_mobile/at_client_mobile.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:iot_receiver/screens/data_owners_screen.dart';
 import 'package:iot_receiver/screens/onboarding_screen.dart';
+import 'package:iot_receiver/widgets/new_data_owner_dialog.dart';
 import '../services/hro2_data_service.dart';
 import '../screens/devices_screen.dart';
 import '../screens/home_screen.dart';
@@ -7,9 +11,17 @@ import '../screens/receivers_screen.dart';
 import 'new_device_dialog.dart';
 import 'new_receiver_dialog.dart';
 
-class HRo2DrawerWidget extends StatelessWidget {
+class HRo2DrawerWidget extends StatefulWidget {
   const HRo2DrawerWidget({Key? key}) : super(key: key);
 
+  @override
+  State<HRo2DrawerWidget> createState() => _HRo2DrawerWidgetState();
+}
+
+class _HRo2DrawerWidgetState extends State<HRo2DrawerWidget> {
+  final bool isAdmin =
+      AtClientManager.getInstance().atClient.getCurrentAtSign() ==
+          "@mwcmanager";
   @override
   Widget build(BuildContext context) {
     return Drawer(
@@ -21,7 +33,7 @@ class HRo2DrawerWidget extends StatelessWidget {
             decoration: BoxDecoration(
               color: Colors.white,
             ),
-            child: Text('HRo2 Options'),
+            child: Text('HRO2 Options'),
           ),
           ListTile(
             title: const Text('See HRo2 readings'),
@@ -29,40 +41,66 @@ class HRo2DrawerWidget extends StatelessWidget {
               Navigator.of(context).pushNamed(HomeScreen.id);
             },
           ),
-          ListTile(
-            title: const Text('See all devices'),
-            onTap: () {
-              Navigator.of(context).pushNamed(DevicesScreen.id);
-            },
-          ),
-          ListTile(
-            title: const Text('Add a new device'),
-            onTap: () {
-              Navigator.of(context).pushNamed(NewHrO2Device.id);
-            },
-          ),
-          ListTile(
-            title: const Text('See all receivers'),
-            onTap: () {
-              Navigator.of(context).pushNamed(ReceiversScreen.id);
-            },
-          ),
-          ListTile(
-            title: const Text('Add a new receiver'),
-            onTap: () {
-              Navigator.of(context).pushNamed(NewHrO2Receiver.id);
-            },
-          ),
+          if (isAdmin)
+            ListTile(
+              title: const Text('See all devices'),
+              onTap: () {
+                Navigator.of(context).pushNamed(DevicesScreen.id);
+              },
+            ),
+          if (isAdmin)
+            ListTile(
+              title: const Text('Add a new device'),
+              onTap: () {
+                Navigator.of(context).pushNamed(NewHrO2Device.id);
+              },
+            ),
+          if (!isAdmin)
+            ListTile(
+              title: const Text('See all receivers'),
+              onTap: () {
+                Navigator.of(context).pushNamed(ReceiversScreen.id);
+              },
+            ),
+          if (!isAdmin)
+            ListTile(
+              title: const Text('Add a new receiver'),
+              onTap: () {
+                Navigator.of(context).pushNamed(NewHrO2Receiver.id);
+              },
+            ),
+          if (isAdmin)
+            ListTile(
+              title: const Text('Add a new data owner'),
+              onTap: () {
+                Navigator.of(context).pushNamed(NewHrO2DataOwner.id);
+              },
+            ),
+          if (isAdmin)
+            ListTile(
+              title: const Text('See all data owners'),
+              onTap: () {
+                Navigator.of(context).pushNamed(DataOwnersScreen.id);
+              },
+            ),
           ListTile(
             title: const Text('Change atSign'),
             onTap: () async {
               Navigator.of(context).pushNamed(OnboardingScreen.id);
             },
           ),
+          if (isAdmin)
+            ListTile(
+              title: const Text('Reset app data'),
+              onTap: () async {
+                Hro2DataService().deleteAllData();
+                Navigator.of(context).pop();
+              },
+            ),
           ListTile(
-            title: const Text('Reset app data'),
-            onTap: () async {
-              await Hro2DataService().deleteAllData();
+            title: const Text('Close'),
+            onTap: () {
+              SystemNavigator.pop();
             },
           ),
         ],

--- a/flutter/iot_receiver/lib/widgets/new_data_owner_dialog.dart
+++ b/flutter/iot_receiver/lib/widgets/new_data_owner_dialog.dart
@@ -2,23 +2,22 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:auto_size_text/auto_size_text.dart';
-import 'package:iot_receiver/forms/receiver_form.dart';
+import 'package:iot_receiver/forms/data_owner_form.dart';
 import 'package:iot_receiver/models/hro2_data_owner.dart';
 import 'package:iot_receiver/models/hro2_device.dart';
-import 'package:iot_receiver/models/hro2_receiver.dart';
-import 'package:iot_receiver/screens/receivers_screen.dart';
+import 'package:iot_receiver/screens/data_owners_screen.dart';
 import 'package:iot_receiver/services/hro2_data_service.dart';
 import 'package:new_gradient_app_bar/new_gradient_app_bar.dart';
 
-class NewHrO2Receiver extends StatefulWidget {
-  const NewHrO2Receiver({Key? key}) : super(key: key);
-  static const String id = '/new_receiver';
+class NewHrO2DataOwner extends StatefulWidget {
+  const NewHrO2DataOwner({Key? key}) : super(key: key);
+  static const String id = '/new_dataOwner';
 
   @override
-  State<NewHrO2Receiver> createState() => _NewHrO2ReceiverState();
+  State<NewHrO2DataOwner> createState() => _NewHrO2DataOwnerState();
 }
 
-class _NewHrO2ReceiverState extends State<NewHrO2Receiver> {
+class _NewHrO2DataOwnerState extends State<NewHrO2DataOwner> {
   final _formKey = GlobalKey<FormBuilderState>();
   final Hro2DataService _hrO2DataService = Hro2DataService();
 
@@ -36,7 +35,7 @@ class _NewHrO2ReceiverState extends State<NewHrO2Receiver> {
     return Scaffold(
         appBar: NewGradientAppBar(
           title: const AutoSizeText(
-            'New Receiver',
+            'New DataOwner',
             minFontSize: 5,
             maxFontSize: 50,
           ),
@@ -82,33 +81,26 @@ class _NewHrO2ReceiverState extends State<NewHrO2Receiver> {
             child: FormBuilder(
                 key: _formKey,
                 child: Column(children: [
-                  const SizedBox(
-                    height: 20,
-                  ),
                   Builder(
-                      builder: (context) => FutureBuilder<List<HrO2DataOwner>>(
-                          future: _hrO2DataService.getDeviceDataOwnerList(),
+                      builder: (context) => FutureBuilder<List<HrO2Device>>(
+                          future: _hrO2DataService.getDeviceList(),
                           builder: (BuildContext context,
-                              AsyncSnapshot<List<HrO2DataOwner>> snapshot) {
+                              AsyncSnapshot<List<HrO2Device>> snapshot) {
                             if (snapshot.hasData) {
-                              return receiverDeviceSelector(
+                              return dataOwnerDeviceSelector(
                                   context,
                                   snapshot.data
                                       ?.map((item) =>
                                           DropdownMenuItem<HrO2Device>(
-                                            value: item.hrO2Device,
-                                            child: Text(
-                                                item.hrO2Device.deviceAtsign),
+                                            value: item,
+                                            child: Text(item.deviceAtsign),
                                           ))
                                       .toList());
                             } else {
                               return const Text("loading");
                             }
                           })),
-                  receiverShortnameForm(context, ''),
-                  receiverAtsignForm(context, ''),
-                  sendHRForm(context, ''),
-                  sendO2Form(context, ''),
+                  dataOwnerAtsignForm(context, ''),
                   Row(
                     children: <Widget>[
                       const SizedBox(width: 20),
@@ -120,7 +112,7 @@ class _NewHrO2ReceiverState extends State<NewHrO2Receiver> {
                         ),
                       ),
                       const Spacer(),
-                      ReceiverSubmitForm(formKey: _formKey),
+                      DataOwnerSubmitForm(formKey: _formKey),
                       const Spacer(),
                       Expanded(
                         child: MaterialButton(
@@ -136,25 +128,17 @@ class _NewHrO2ReceiverState extends State<NewHrO2Receiver> {
                             if (_formKey.currentState!.validate()) {
                               HrO2Device device = _formKey.currentState!
                                   .fields['device_selector']!.value;
-                              String receiverAtsign = _formKey
-                                  .currentState!.fields['@receiver']!.value;
-                              String receiverShortname = _formKey
-                                  .currentState!.fields['shortName']!.value;
-                              var sendHr = _formKey
-                                  .currentState!.fields['sendHR']!.value;
-                              var sendO2 = _formKey
-                                  .currentState!.fields['sendO2']!.value;
-                              var newReceiver = HrO2Receiver(
-                                  receiverAtsign: receiverAtsign,
-                                  receiverShortname: receiverShortname,
-                                  hrO2Device: device,
-                                  sendHR: sendHr,
-                                  sendO2: sendO2);
+                              String dataOwnerAtsign = _formKey
+                                  .currentState!.fields['@dataOwner']!.value;
+                              var newDataOwner = HrO2DataOwner(
+                                dataOwnerAtsign: dataOwnerAtsign,
+                                hrO2Device: device,
+                              );
                               await _hrO2DataService
-                                  .addReceiverToList(newReceiver);
+                                  .addDataOwnerToList(newDataOwner);
                               if (mounted) {
                                 Navigator.of(context)
-                                    .pushNamed(ReceiversScreen.id);
+                                    .pushNamed(DataOwnersScreen.id);
                               }
                             } else {
                               Navigator.pop(context, null);


### PR DESCRIPTION
Adding in data_owner object and integrating it into the data flow

<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Adding in shared data keys persistence to:
1. 2. Hro2DataService().addDataOwnerToList to allow a device to retrieve the list of HrO2DataOwner objects so it can retrieve the requisite HrO2Receiver objects.
2. Hro2DataService().addReceiverToList() to allow a device to retrieve the list of HrO2Receiver objects for a HrO2DataOwner.


**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
added in shared data keys implementation to allow interaction between atSigns