### PR TITLE
fix: Correct repo name in systemd services

### DIFF
--- a/systemd/etc/systemd/system/mwc-display.service
+++ b/systemd/etc/systemd/system/mwc-display.service
@@ -8,7 +8,7 @@ Type=simple
 ExecStartPre=/bin/sleep 30
 Restart=always
 RestartSec=3
-ExecStart=/usr/bin/screen -DmS mwcdisplay /home/pi/git/github.com/atsign-company/mwc_demo/python/display_hro2_from_mqtt.py
+ExecStart=/usr/bin/screen -DmS mwcdisplay /home/pi/git/github.com/atsign-foundation/mwc_demo/python/display_hro2_from_mqtt.py
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/etc/systemd/system/mwc-sender.service
+++ b/systemd/etc/systemd/system/mwc-sender.service
@@ -8,7 +8,7 @@ Type=simple
 ExecStartPre=/bin/sleep 30
 Restart=always
 RestartSec=3
-WorkingDirectory=/home/pi/git/github.com/atsign-company/mwc_demo/dart/iot_sender
+WorkingDirectory=/home/pi/git/github.com/atsign-foundation/mwc_demo/dart/iot_sender
 ExecStart=/usr/bin/screen -DmS mwcsender ./sender -a "@sendingatsign" -o "@receivingatsign" -n <devicename> -v
 
 [Install]

--- a/systemd/etc/systemd/system/mwc-spub.service
+++ b/systemd/etc/systemd/system/mwc-spub.service
@@ -8,7 +8,7 @@ Type=simple
 ExecStartPre=/bin/sleep 30
 Restart=always
 RestartSec=3
-WorkingDirectory=/home/pi/git/github.com/atsign-company/mwc_demo/dart/iot_sender
+WorkingDirectory=/home/pi/git/github.com/atsign-foundation/mwc_demo/dart/iot_sender
 ExecStart=/usr/bin/screen -DmS mwcspub ./spub
 
 [Install]


### PR DESCRIPTION
systemd services were still based on being in old atsign-company repo

**- What I did**

moved to atsign-foundation
changed line endings to LF

**- How to verify it**

testing on mwc-gary Pi

**- Description for the changelog**

fix: Correct repo name in systemd services